### PR TITLE
Removing redudant render property from comboboxView

### DIFF
--- a/src/comboboxView.js
+++ b/src/comboboxView.js
@@ -7,7 +7,7 @@ define(function(require, exports, module) {
   var classnames = require('classnames');
 
 // properties of model which changes causes call of render function
-  var renderProperties = ['selectedId', 'isDisabled', 'isLoading', 'isOpen', 'theme', 'isWarning', 'hasError'];
+  var renderProperties = ['selectedId', 'isDisabled', 'isLoading', 'theme', 'isWarning', 'hasError'];
 
   module.exports = Backbone.View.extend({
     toggleTemplate: toggleTemplate,


### PR DESCRIPTION
The combobox view should not rerender itself on `isOpen` property change. The only thing that should happen in this case is rendering the subview (`dropdownView`), which is already implemented by another listener.
