### PR TITLE
Fixing properties passed to comboboxView template

### DIFF
--- a/src/comboboxView.ejs
+++ b/src/comboboxView.ejs
@@ -1,8 +1,8 @@
 <div class="c-combobox__toggle js-combobox__toggle <%- classNames %>">
   <div class="c-combobox__text-wrapper">
-    <% if (typeof selected !== 'undefined') { %>
-      <% if (typeof selected.get('icon') !== 'undefined') { %><i class="<%- selected.get('icon') %>"></i><% } %>
-      <span class="c-combobox__text"><%= label %></span>
+    <% if (typeof model.getSelectedItem() !== 'undefined') { %>
+      <% if (typeof model.getSelectedItem().get('icon') !== 'undefined') { %><i class="<%- model.getSelectedItem().get('icon') %>"></i><% } %>
+      <span class="c-combobox__text"><%= model.getLabel() %></span>
     <% } else { %>
       <!-- Nothing has been selected -->
       &nbsp;

--- a/src/comboboxView.js
+++ b/src/comboboxView.js
@@ -55,13 +55,10 @@ define(function(require, exports, module) {
         this.el.setAttribute('class', this.el.getAttribute('class').replace(/\bt-combobox--\S+/g, ''));
       }
 
-      var selectedItem = this.model.getSelectedItem();
-
       this.$el.html(
         this.toggleTemplate({
           classNames: classnames(classes),
-          selected: selectedItem,
-          label: this.model.getLabel()
+          model: this.model
         })
       );
 


### PR DESCRIPTION
Instead of passing preselected properties to template we should pass the model and even better the model and the view model. This way we can easily extend the template in child components without replacing the whole render method.
