### PR TITLE
Cleaning up attached events

### DIFF
--- a/src/dropdownView.js
+++ b/src/dropdownView.js
@@ -158,6 +158,7 @@ define(function(require, exports, module) {
       if (this.first) {
         WINDOW.off('.combobox');
         DOCUMENT.off('.combobox');
+        BODY[0].removeEventListener('click', this.captureClickOnBodyHandler, true);
       }
 
       if (this._dropdownView) {


### PR DESCRIPTION
All attached events should be dropped on `dropdownView` remove.
